### PR TITLE
Update sdk_auto_install.rst

### DIFF
--- a/sdk_auto_install.rst
+++ b/sdk_auto_install.rst
@@ -48,8 +48,8 @@ For example for the Apache Flex SDK this would be something like this: ::
 	repositories {
 		ivy {
 			name 'Apache'
-			// pattern for url http://apache.cu.be/flex/4.9.0/binaries/apache-flex-sdk-4.9.0-bin.zip
-			artifactPattern 'http://apache.cu.be/flex/[revision]/binaries/[module]-[revision]-bin.[ext]'
+			// pattern for url http://archive.apache.org/dist/flex/4.9.0/binaries/apache-flex-sdk-4.9.0-bin.zip
+			artifactPattern 'http://archive.apache.org/dist/flex/[revision]/binaries/[module]-[revision]-bin.[ext]'
 		}
 	}
 	


### PR DESCRIPTION
In the actual url pattern, you reference the page with only actual (latest) build. So everyone has to use it. If you try, to run a build, when new version of sdk is released, and you don't have the build in your local cache, build fails. (for example http://archive.apache.org/dist/flex/4.9.0/binaries/apache-flex-sdk-4.9.0-bin.zip doesn't exist). This fix make reference to repository, where're all versions of SDK, so you're not obligated to changed version every time new SDK is released.
